### PR TITLE
CONTRIB-7772: workaround for phpunit fatal error

### DIFF
--- a/classes/output/email/renderer.php
+++ b/classes/output/email/renderer.php
@@ -26,6 +26,9 @@ namespace mod_hsuforum\output\email;
 
 defined('MOODLE_INTERNAL') || die();
 
+// To ensure class is picked up during unit tests.
+require_once($CFG->dirroot . '/mod/hsuforum/renderer.php');
+
 /**
  * Forum post renderable.
  *


### PR DESCRIPTION
This fixes fatal error when running unit tests (in 3.7.1). 